### PR TITLE
Perform case insensitive match for osPlatfrom in release name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: "tag containing binary to install"
     default: latest
     required: true
+  fileRegexp:
+    description: "the regexp to match the filename of the release to download"
+    required: false
 branding:
   icon: 'archive'  
   color: 'green'

--- a/lib/main.js
+++ b/lib/main.js
@@ -71,7 +71,7 @@ function run() {
                     tag: tag,
                 });
             }
-            let re = new RegExp(`${osPlatform}.*tar.gz`);
+            let re = new RegExp(`${osPlatform}.*tar.gz`, "i");
             let asset = getReleaseUrl.data.assets.find(obj => {
                 return re.test(obj.name);
             });

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,6 +51,7 @@ function run() {
             if (!tag) {
                 throw new Error(`Tag not specified`);
             }
+            const fileRegexp = core.getInput("fileRegexp");
             const [owner, project] = repo.split("/");
             let osPlatform = os.platform();
             if (osPlatform != "linux" && osPlatform != "darwin") {
@@ -72,6 +73,9 @@ function run() {
                 });
             }
             let re = new RegExp(`${osPlatform}.*tar.gz`, "i");
+            if (fileRegexp) {
+                re = new RegExp(fileRegexp, "i");
+            }
             let asset = getReleaseUrl.data.assets.find(obj => {
                 return re.test(obj.name);
             });

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ async function run() {
             })
         }
 
-        let re = new RegExp(`${osPlatform}.*tar.gz`)
+        let re = new RegExp(`${osPlatform}.*tar.gz`, "i")
         let asset = getReleaseUrl.data.assets.find(obj => {
             return re.test(obj.name)
         })

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ async function run() {
                 `Tag not specified`
             )
         }
+        const fileRegexp = core.getInput("fileRegexp");
 
         const [owner, project] = repo.split("/")
 
@@ -55,6 +56,10 @@ async function run() {
         }
 
         let re = new RegExp(`${osPlatform}.*tar.gz`, "i")
+	if (fileRegexp) {
+	    re = new RegExp(fileRegexp, "i")
+	}
+
         let asset = getReleaseUrl.data.assets.find(obj => {
             return re.test(obj.name)
         })


### PR DESCRIPTION
Some repositories do have Linux or Darwin in the release name.