### PR TITLE
fix(auth): missing auth string in download release

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,11 +1,7 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -18,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -59,7 +55,7 @@ function run() {
                         core.info(`Retrying after ${retryAfter} seconds.`);
                         return true;
                     },
-                } }, (0, utils_1.getOctokitOptions)(token)));
+                } }, utils_1.getOctokitOptions(token)));
             const repo = core.getInput("repo");
             if (!repo) {
                 throw new Error(`Repo was not specified`);
@@ -156,9 +152,12 @@ function run() {
                 throw new Error(`Could not find a release for ${tag}. Found: ${found}`);
             }
             const extractFn = getExtractFn(asset.name);
-            const url = asset.browser_download_url;
+            const url = asset.url;
+            const authString = `bearer ${token}`;
             core.info(`Downloading ${project} from ${url}`);
-            const binPath = yield tc.downloadTool(url);
+            const binPath = yield tc.downloadTool(url, '', authString, {
+                accept: "application/octet-stream"
+            });
             yield extractFn(binPath, dest);
             if (cacheEnabled && cacheKey !== undefined) {
                 try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,11 +160,13 @@ async function run() {
 
         const extractFn = getExtractFn(asset.name);
 
-        const url = asset.browser_download_url
+        const url = asset.url
         const authString = `bearer ${token}`
 
         core.info(`Downloading ${project} from ${url}`)
-        const binPath = await tc.downloadTool(url, '', authString);
+        const binPath = await tc.downloadTool(url, '', authString, {
+            accept: "application/octet-stream"
+        });
         await extractFn(binPath, dest);
 
         if (cacheEnabled && cacheKey !== undefined) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,9 +161,10 @@ async function run() {
         const extractFn = getExtractFn(asset.name);
 
         const url = asset.browser_download_url
+        const authString = `bearer ${token}`
 
         core.info(`Downloading ${project} from ${url}`)
-        const binPath = await tc.downloadTool(url);
+        const binPath = await tc.downloadTool(url, '', authString);
         await extractFn(binPath, dest);
 
         if (cacheEnabled && cacheKey !== undefined) {


### PR DESCRIPTION
I was facing some 404 when trying to download release from private organization repository.
It now use the asset url + auth string instead of raw `browser_download_url`

![image](https://user-images.githubusercontent.com/25364623/150773884-f91c1642-89d4-45b1-a232-e31079612df7.png)

---

![image](https://user-images.githubusercontent.com/25364623/150786565-18055837-6d7c-4aa5-9e72-9cfc291aa156.png)
