### PR TITLE
Add auto tagging of major version

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,13 @@
+on:
+  release:
+    types: [published, edited]
+jobs:
+  tag-major:
+    name: Push major-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@latest
+        env:
+          GITHUB_TOKEN: '${{ github.token }}'
+        with:
+          publish_latest_tag: false


### PR DESCRIPTION
This means when a user creates a tag of v1.1.0 of the GHA, then we
create the associated v1 tag as well

This allows a user to be able to be less specific in versions of
the action

```
steps:
  - name: Install go-task
    uses: jaxxstorm/action-install-gh-release@v1
```
