### PR TITLE
Fix errors from concurrent builds with cache: enable

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -161,7 +161,21 @@ function run() {
             const binPath = yield tc.downloadTool(url);
             yield extractFn(binPath, dest);
             if (cacheEnabled && cacheKey !== undefined) {
-                yield cache.saveCache([dest], cacheKey);
+                try {
+                    yield cache.saveCache([dest], cacheKey);
+                }
+                catch (error) {
+                    const typedError = error;
+                    if (typedError.name === cache.ValidationError.name) {
+                        throw error;
+                    }
+                    else if (typedError.name === cache.ReserveCacheError.name) {
+                        core.info(typedError.message);
+                    }
+                    else {
+                        core.warning(typedError.message);
+                    }
+                }
             }
             core.addPath(dest);
             core.info(`Successfully extracted ${project} to ${dest}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -167,7 +167,18 @@ async function run() {
         await extractFn(binPath, dest);
 
         if (cacheEnabled && cacheKey !== undefined) {
-            await cache.saveCache([dest], cacheKey);
+            try {
+                await cache.saveCache([dest], cacheKey);
+            } catch (error: unknown) {
+                const typedError = error as Error;
+                if (typedError.name === cache.ValidationError.name) {
+                    throw error;
+                } else if (typedError.name === cache.ReserveCacheError.name) {
+                    core.info(typedError.message);
+                } else {
+                    core.warning(typedError.message);
+                }
+            }
         }
 
         core.addPath(dest);

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,7 +169,7 @@ async function run() {
         if (cacheEnabled && cacheKey !== undefined) {
             try {
                 await cache.saveCache([dest], cacheKey);
-            } catch (error: unknown) {
+            } catch (error) {
                 const typedError = error as Error;
                 if (typedError.name === cache.ValidationError.name) {
                     throw error;


### PR DESCRIPTION
When test-driving `cache: enable` at scale, https://github.com/pulumi/pulumi/pull/9628 - it seems to work and result in cache hits, but sometimes there is a race with an exception on a cache miss:

```
Error: Unable to reserve cache with key action-install-gh-release/pulumi/pulumictl/v0.0.31/linux-x64, another job may be creating this cache. More details: Cache already exists. Scope: refs/pull/9628/merge, Key: action-install-gh-release/pulumi/pulumictl/v0.0.31/linux-x64, Version: b7e495078f01e0ba3aac532b3e4b5eb2809dcb6b5752b5d432363c38c69bce7a
```

I'm borrowing some error-handling code here found in actions/cache repo https://github.com/actions/cache/blob/d55d005ab0cbd9310b447311bcd1661be90843f5/src/save.ts#L47

It should be OK to downgrade this to a warning; in the case of a race, the first-write-wins is fine. The key of the cache uniquely determines the binary version.
