### PR TITLE
Make the tag input optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   tag:
     description: "tag containing binary to install"
     default: latest
-    required: true
+    required: false
   platform:
     description: "OS Platform to match in release package. Specify this parameter if the repository releases do not follow a normal convention otherwise it will be auto-detected."
     required: false


### PR DESCRIPTION
The tag input has a default value so it shouldn't be required.