### PR TITLE
Set a token default and support private repos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           repo: pulumi/crd2pulumi
           tag: v1.0.10
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   change-aws-credentials:
     strategy:
       matrix:
@@ -35,8 +33,6 @@ jobs:
         with:
           repo: jaxxstorm/change-aws-credentials
           tag: v0.3.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: change-aws-credentials version
   tf2pulumi:
     strategy:
@@ -52,8 +48,6 @@ jobs:
         with:
           repo: pulumi/tf2pulumi
           tag: ${{ matrix.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: tf2pulumi version
   tfsec:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,4 @@ jobs:
           tag: ${{ matrix.version }}
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: tfsec --version

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Use a `repo` scoped [Personal Access Token (PAT)](https://docs.github.com/en/git
 
 ```yaml
 steps:
-  - name: Install go-task
+  - name: Install private tool
     uses: jaxxstorm/action-install-gh-release@v1.5.0
     with: # Grab from a private repository
       token: ${{ secrets.MY_PAT }}
-      repo: go-task/task
+      repo: my-org/my-private-repo
 ```
 
 ### Caching

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This is especially useful when installing arbitrary Go binaries. It can lookup t
 
 ## Usage
 
-This action requires a Github Token (`GITHUB_TOKEN`) in the environment to authenticate with.
-
 ### Grab the Latest Version
 
 ```yaml
@@ -17,43 +15,43 @@ steps:
     uses: jaxxstorm/action-install-gh-release@v1.5.0
     with: # Grab the latest version
       repo: go-task/task
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Github token scoped to step
 ```
 
 ### Grab a Specific Tags
 
 ```yaml
 # ...
-jobs:
-  my_job:
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Github token scoped to job
-    steps:
-      - name: Install tf2pulumi
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with: # Grab a specific tag
-          repo: pulumi/tf2pulumi
-          tag: v0.7.0
+steps:
+  - name: Install tf2pulumi
+    uses: jaxxstorm/action-install-gh-release@v1.5.0
+    with: # Grab a specific tag
+      repo: pulumi/tf2pulumi
+      tag: v0.7.0
 ```
 
 ### Grab a Specific Platform And/Or Architecture
 
 ```yaml
-name: my_action
+steps:
+  - name: Install tfsec
+    uses: jaxxstorm/action-install-gh-release@v1.5.0
+    with: # Grab a specific platform and/or architecture
+      repo: aquasecurity/tfsec
+      platform: linux
+      arch: x86-64
+```
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Github token scoped to action
+### Grab from a private repository
 
-jobs:
-  my_job:
-    steps:
-      - name: Install tfsec
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with: # Grab a specific platform and/or architecture
-          repo: aquasecurity/tfsec
-          platform: linux
-          arch: x86-64
+Use a `repo` scoped [Personal Access Token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) that has been created on a user with access to the private repository.
+
+```yaml
+steps:
+  - name: Install go-task
+    uses: jaxxstorm/action-install-gh-release@v1.5.0
+    with: # Grab from a private repository
+      token: ${{ secrets.MY_PAT }}
+      repo: go-task/task
 ```
 
 ### Caching
@@ -62,17 +60,13 @@ This action can use [actions/cache](https://github.com/actions/cache) under the 
 
 ```yaml
 # ...
-jobs:
-  my_job:
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Github token scoped to job
-    steps:
-      - name: Install tf2pulumi
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with: # Grab a specific tag with caching
-          repo: pulumi/tf2pulumi
-          tag: v0.7.0
-          cache: enable
+steps:
+  - name: Install tf2pulumi
+    uses: jaxxstorm/action-install-gh-release@v1.5.0
+    with: # Grab a specific tag with caching
+      repo: pulumi/tf2pulumi
+      tag: v0.7.0
+      cache: enable
 ```
 
 Caching helps avoid

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,9 @@ name: "Install a binary from GitHub releases"
 description: "Install binaries from GitHub releases"
 author: "Lee Briggs"
 inputs:
+  token:
+    description: 'GITHUB_TOKEN or a `repo` scoped Personal Access Token (PAT)'
+    default: ${{ github.token }}
   repo:
     description: "GitHub repo where binary is located"
     required: true

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,11 +1,7 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -18,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -44,10 +40,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             // set up auth/environment
-            const token = process.env['GITHUB_TOKEN'];
-            if (!token) {
-                throw new Error(`No GitHub token found`);
-            }
+            const token = process.env['GITHUB_TOKEN'] || core.getInput("token");
             const octokit = new ThrottlingOctokit(Object.assign({ throttle: {
                     onRateLimit: (retryAfter, options) => {
                         core.warning(`RateLimit detected for request ${options.method} ${options.url}.`);
@@ -59,7 +52,7 @@ function run() {
                         core.info(`Retrying after ${retryAfter} seconds.`);
                         return true;
                     },
-                } }, (0, utils_1.getOctokitOptions)(token)));
+                } }, utils_1.getOctokitOptions(token)));
             const repo = core.getInput("repo");
             if (!repo) {
                 throw new Error(`Repo was not specified`);
@@ -156,9 +149,11 @@ function run() {
                 throw new Error(`Could not find a release for ${tag}. Found: ${found}`);
             }
             const extractFn = getExtractFn(asset.name);
-            const url = asset.browser_download_url;
+            const url = asset.url;
             core.info(`Downloading ${project} from ${url}`);
-            const binPath = yield tc.downloadTool(url);
+            const binPath = yield tc.downloadTool(url, undefined, `token ${token}`, {
+                accept: 'application/octet-stream'
+            });
             yield extractFn(binPath, dest);
             if (cacheEnabled && cacheKey !== undefined) {
                 try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,12 +21,7 @@ async function run() {
     try {
 
         // set up auth/environment
-        const token = process.env['GITHUB_TOKEN']
-        if (!token) {
-            throw new Error(
-                `No GitHub token found`
-            )
-        }
+        const token = process.env['GITHUB_TOKEN'] || core.getInput("token")
         const octokit = new ThrottlingOctokit({
             throttle: {
                 onRateLimit: (retryAfter, options) => {
@@ -160,10 +155,16 @@ async function run() {
 
         const extractFn = getExtractFn(asset.name);
 
-        const url = asset.browser_download_url
+        const url = asset.url
 
         core.info(`Downloading ${project} from ${url}`)
-        const binPath = await tc.downloadTool(url);
+        const binPath = await tc.downloadTool(url,
+            undefined,
+            `token ${token}`,
+            {
+              accept: 'application/octet-stream'
+            }
+        );
         await extractFn(binPath, dest);
 
         if (cacheEnabled && cacheKey !== undefined) {


### PR DESCRIPTION
The aim of this PR is to improve the interface and allow the action to work for private repositories.

- Adds a `token` input that defaults to the default `GITHUB_TOKEN` in the repository.
- Supersedes https://github.com/jaxxstorm/action-install-gh-release/pull/11
