### PR TITLE
Ensure that binaries-location is used when caching is enabled

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -158,7 +158,8 @@ function run() {
                 let ok = yield cache.restoreCache([dest], cacheKey);
                 if (ok !== undefined) {
                     core.info(`Found ${project} in the cache: ${dest}`);
-                    core.addPath(dest);
+                    core.info(`Adding ${finalBinLocation} to the path`);
+                    core.addPath(finalBinLocation);
                     return;
                 }
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,7 +152,8 @@ async function run() {
             let ok = await cache.restoreCache([dest], cacheKey);
             if (ok !== undefined) {
                 core.info(`Found ${project} in the cache: ${dest}`)
-                core.addPath(dest);
+                core.info(`Adding ${finalBinLocation} to the path`);
+                core.addPath(finalBinLocation);
                 return;
             }
         }


### PR DESCRIPTION
In [this build](https://github.com/opencastsoftware/wasm4j/actions/runs/4488885674/jobs/7894028134) I found that although a cache entry was found and restored for the binaries that were installed in a previous build, the binaries were not added to the path.
When caching was disabled everything worked as expected.
I think that we need to use the `finalBinLocation` in the code path that uses the cache.