### PR TITLE
remove opentelemetry latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,13 +147,11 @@ jobs:
     strategy:
       matrix:
         version: [ "latest" ]
-        runs-on: [ "ubuntu-latest", "macos-latest"]
+        runs-on: [ "ubuntu-latest" ]
         arch: [ "amd64" ]
         include:
           - runs-on: "ubuntu-latest"
             platform: linux
-          - runs-on: "macos-latest"
-            platform: darwin
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
   opentelemetry-ocb:
     strategy:
       matrix:
-        version: [ "v0.62.1", "v0.62.0", "latest" ]
+        version: [ "v0.62.1", "v0.62.0" ]
         runs-on: [ "ubuntu-latest", "macos-latest"]
         arch: [ "amd64" ]
         include:


### PR DESCRIPTION
Have removed two releases from the tests:

- Wasmer's darwin build seems to pack into a zip, and then a tar, so it was failing
- Opentelemtry no longer adds binaries to releases, so removing latests