### PR TITLE
Handle 'EXDEV: cross-device link not permitted'

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -238,21 +238,38 @@ function run() {
                     fs.mkdirSync(dest, { 'recursive': true });
                     const outputPath = path.join(dest, renameTo !== "" ? renameTo : path.basename(binPath));
                     core.info(`Created output directory ${dest}`);
+                    var moveFailed = false;
                     try {
                         fs.renameSync(binPath, outputPath);
-                        core.info(`Moved release asset ${asset.name} to ${outputPath}`);
-                        if (chmodTo !== "") {
-                            try {
-                                fs.chmodSync(outputPath, chmodTo);
-                                core.info(`chmod'd ${outputPath} to ${chmodTo}`);
-                            }
-                            catch (chmodErr) {
-                                core.setFailed(`Failed to chmod ${outputPath} to ${chmodTo}: ${chmodErr}`);
-                            }
-                        }
                     }
                     catch (renameErr) {
-                        core.setFailed(`Failed to move downloaded release asset ${asset.name} from ${binPath} to ${outputPath}: ${renameErr}`);
+                        if (renameErr instanceof Error && 'code' in renameErr && renameErr.code === 'EXDEV') {
+                            core.debug(`Falling back to copy and remove, due to: ${renameErr}`);
+                            try {
+                                fs.copyFileSync(binPath, outputPath);
+                                fs.rmSync(binPath);
+                            }
+                            catch (copyRemoveErr) {
+                                moveFailed = true;
+                                core.setFailed(`Failed to copy and remove downloaded release asset ${asset.name} from ${binPath} to ${outputPath}: ${copyRemoveErr}`);
+                            }
+                        }
+                        else {
+                            moveFailed = true;
+                            core.setFailed(`Failed to move downloaded release asset ${asset.name} from ${binPath} to ${outputPath}: ${renameErr}`);
+                        }
+                    }
+                    if (!moveFailed) {
+                        core.info(`Moved release asset ${asset.name} to ${outputPath}`);
+                    }
+                    if ((chmodTo !== "") && !moveFailed) {
+                        try {
+                            fs.chmodSync(outputPath, chmodTo);
+                            core.info(`chmod'd ${outputPath} to ${chmodTo}`);
+                        }
+                        catch (chmodErr) {
+                            core.setFailed(`Failed to chmod ${outputPath} to ${chmodTo}: ${chmodErr}`);
+                        }
                     }
                 }
                 catch (err) {


### PR DESCRIPTION
The flow for blob binary downloading can fail if the runner is running in a context where the mount points for the `hostedtoolcache` is different than the workspace, since it's not possible to rename across different volumes.

This PR handles that error in particular and falls back to trying to copy the source the data and then removing it instead. 