### PR TITLE
Turn on renovate best practice preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    'config:best-practices'
   ]
 }


### PR DESCRIPTION
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions suggests 

> Pin actions to a full length commit SHA
> 
> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. When selecting a SHA, you should verify it is from the action's repository and not a repository fork.
> 

Renovate best practice automates this process, see https://docs.renovatebot.com/upgrade-best-practices/#extends-helperspingithubactiondigests 
> We recommend pinning all Actions. That's why the helpers:pinGitHubActionDigests preset pins all GitHub Actions.
> 
> For an in-depth explanation why you should pin your Github Actions, read the [Palo Alto Networks blogpost about the GitHub Actions worm](https://www.paloaltonetworks.com/blog/prisma-cloud/github-actions-worm-dependencies/).
