### PR TITLE
upgrades run-as node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ branding:
   icon: "archive"
   color: "green"
 runs:
-  using: "node16"
+  using: "node20"
   main: "lib/main.js"


### PR DESCRIPTION
GHA is currently giving users a warning this action is using a deprecated version of Node