### PR TITLE
Add aarch64 as a known alternative to arm64

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -98,6 +98,9 @@ function run() {
                     case "x64":
                         osMatch.push("x86_64", "x64", "amd64");
                         break;
+                    case "arm64":
+                        osMatch.push("aarch64", "arm64");
+                        break;
                     default:
                         osMatch.push(os.arch());
                         break;

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,6 +91,9 @@ async function run() {
                 case "x64":
                     osMatch.push("x86_64", "x64", "amd64")
                     break;
+                case "arm64":
+                    osMatch.push("aarch64", "arm64")
+                    break;
                 default:
                     osMatch.push(os.arch())
                     break;


### PR DESCRIPTION
aarch64 is the official name for the 64-bit ARM architecture.

For example,
https://github.com/obi1kenobi/cargo-semver-checks/releases/tag/v0.31.0 has releases with names:

* cargo-semver-checks-aarch64-apple-darwin.tar.gz
* cargo-semver-checks-aarch64-unknown-linux-gnu.tar.gz
* cargo-semver-checks-aarch64-unknown-linux-musl.tar.gz

which are currently not found by this action on e.g. an arm64 apple github runner.