### PR TITLE
Install latest prerelease assets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,3 +191,17 @@ jobs:
           platform: ubuntu
           cache: enable
       - run: sui --version
+  terrabuild:
+    strategy:
+      matrix:
+        runs-on: ["ubuntu-latest"]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v1
+      - run: npm ci
+      - run: npm run build
+      - uses: ./
+        with:
+          repo: magnusopera/terrabuild
+          prerelease: true
+      - run: terrabuild version

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ steps:
       repo: go-task/task
 ```
 
+### Grab the Latest PreRelease Version
+
+```yaml
+# ...
+steps:
+  - name: Install go-task
+    uses: jaxxstorm/action-install-gh-release@v1.10.0
+    with: # Grab the latest version
+      repo: go-task/task
+      prerelease: true
+```
+
 ### Grab Specific Tags
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "tag containing binary to install"
     default: latest
     required: true
+  prerelease:
+    description: "considerer prerelease for latest tag"
+    default: "false"
+    required: false
   platform:
     description: "OS Platform to match in release package. Specify this parameter if the repository releases do not follow a normal convention otherwise it will be auto-detected."
     required: false

--- a/lib/main.js
+++ b/lib/main.js
@@ -213,7 +213,6 @@ function run() {
             let release = yield getRelease();
             if (!release) {
                 throw new Error(`Could not find release for tag ${tag}${prerelease ? ' with prerelease' : ''}.`);
-
             }
             // Build regular expressions for all the target triple components
             //

--- a/lib/main.js
+++ b/lib/main.js
@@ -64,7 +64,7 @@ function run() {
             }
             let tag = core.getInput("tag");
             tag = !tag ? "latest" : tag;
-            let prerelease = !!core.getInput("prerelease");
+            let prerelease = core.getInput("prerelease") === "true";
             const cacheEnabled = (core.getInput("cache") === "enable")
                 && tag !== "latest"
                 && tag !== "";

--- a/lib/main.js
+++ b/lib/main.js
@@ -64,6 +64,7 @@ function run() {
             }
             let tag = core.getInput("tag");
             tag = !tag ? "latest" : tag;
+            let prerelease = !!core.getInput("prerelease");
             const cacheEnabled = (core.getInput("cache") === "enable")
                 && tag !== "latest"
                 && tag !== "";
@@ -163,30 +164,44 @@ function run() {
                     return;
                 }
             }
-            let getReleaseUrl;
-            if (tag === "latest") {
-                getReleaseUrl = yield octokit.rest.repos.getLatestRelease({
-                    owner: owner,
-                    repo: project,
-                });
-            }
-            else {
-                getReleaseUrl = yield octokit.rest.repos.getReleaseByTag({
-                    owner: owner,
-                    repo: project,
-                    tag: tag,
-                });
+            let getRelease = () => __awaiter(this, void 0, void 0, function* () {
+                if (tag === "latest") {
+                    if (!prerelease) {
+                        let release = yield octokit.rest.repos.getLatestRelease({
+                            owner: owner,
+                            repo: project,
+                        });
+                        return release.data;
+                    }
+                    else {
+                        let releases = (yield octokit.rest.repos.listReleases()).data;
+                        let release = releases.find(release => release.prerelease);
+                        return release;
+                    }
+                }
+                else {
+                    let release = yield octokit.rest.repos.getReleaseByTag({
+                        owner: owner,
+                        repo: project,
+                        tag: tag,
+                    });
+                    return release.data;
+                }
+            });
+            let release = yield getRelease();
+            if (!release) {
+                throw new Error(`Could not find release for tag ${tag}${prerelease ? ' with prerelease' : ''}.`);
             }
             let osMatchRegexForm = `(${osMatch.join('|')})`;
             let re = new RegExp(`${osMatchRegexForm}.*${osMatchRegexForm}.*${extMatchRegexForm}`);
-            let asset = getReleaseUrl.data.assets.find(obj => {
+            let asset = release.assets.find(obj => {
                 core.info(`searching for ${obj.name} with ${re.source}`);
                 let normalized_obj_name = obj.name.toLowerCase();
                 return re.test(normalized_obj_name);
             });
             if (!asset) {
-                const found = getReleaseUrl.data.assets.map(f => f.name);
-                throw new Error(`Could not find a release for ${tag}. Found: ${found}`);
+                const found = release.assets.map(f => f.name);
+                throw new Error(`Could not find asset for ${tag}. Found: ${found}`);
             }
             const url = asset.url;
             core.info(`Downloading ${project} from ${url}`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -164,23 +164,38 @@ function run() {
                     return;
                 }
             }
-            let getRelease = () => __awaiter(this, void 0, void 0, function* () {
+            const getRelease = () => __awaiter(this, void 0, void 0, function* () {
                 if (tag === "latest") {
-                    if (!prerelease) {
-                        let release = yield octokit.rest.repos.getLatestRelease({
+                    if (prerelease) {
+                        let page = 1;
+                        const per_page = 30;
+                        while (true) {
+                            const { data: releases } = yield octokit.rest.repos.listReleases({
+                                owner: owner,
+                                repo: project,
+                                per_page,
+                                page
+                            });
+                            const release = releases.find(release => release.prerelease);
+                            if (!!release) {
+                                return release;
+                            }
+                            if (releases.length < per_page) {
+                                return undefined;
+                            }
+                            ++page;
+                        }
+                    }
+                    else {
+                        const release = yield octokit.rest.repos.getLatestRelease({
                             owner: owner,
                             repo: project,
                         });
                         return release.data;
                     }
-                    else {
-                        let releases = (yield octokit.rest.repos.listReleases()).data;
-                        let release = releases.find(release => release.prerelease);
-                        return release;
-                    }
                 }
                 else {
-                    let release = yield octokit.rest.repos.getReleaseByTag({
+                    const release = yield octokit.rest.repos.getReleaseByTag({
                         owner: owner,
                         repo: project,
                         tag: tag,

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ async function run() {
         let tag = core.getInput("tag");
         tag = !tag ? "latest" : tag
 
-        let prerelease = !!core.getInput("prerelease")
+        let prerelease = core.getInput("prerelease") === "true"
 
         const cacheEnabled = (core.getInput("cache") === "enable")
             && tag !== "latest"


### PR DESCRIPTION
Hello,

This is un unsolicited PR to allow finding the latest prerelease. `action-install-gh-release` only supports tags (with latest) but I need to support prerelease workflow. So here I go with this PR !

To enable this feature, one must set in configuration (`README.md` updated):
```
tag: latest # optional as this is the default
prerelease: true
```

Implementation notes:
* This PR implements paging to find the first prerelease from all releases (because GH api does not allow server-side filtering).
* Previous behavior is not changed: default value for prerelease is `false`.
* On error side, I changed a little bit to disambiguate release vs asset to give a more informed error.

Thanks!