### PR TITLE
feat: allow configurable project names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           repo: jaxxstorm/connecti
           arch: amd64
           cache: enable
+
   crd2pulumi:
     strategy:
       matrix:
@@ -35,6 +36,7 @@ jobs:
         with:
           repo: pulumi/crd2pulumi
           tag: v1.0.10
+
   change-aws-credentials:
     strategy:
       matrix:
@@ -49,6 +51,7 @@ jobs:
           repo: jaxxstorm/change-aws-credentials
           tag: v0.4.0
       - run: change-aws-credentials version
+
   tfsec:
     strategy:
       matrix:
@@ -74,6 +77,7 @@ jobs:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
       - run: tfsec --version
+
   opentelemetry-ocb:
     strategy:
       matrix:
@@ -102,6 +106,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: ocb version
+
   mozilla-grcov:
     strategy:
       matrix:
@@ -128,6 +133,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: grcov --version
+
   wasmer:
     strategy:
       matrix:
@@ -150,6 +156,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: wasmer --version
+
   prometheus:
     strategy:
       matrix:
@@ -175,6 +182,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: promtool --version
+
   sui:
     strategy:
       matrix:
@@ -191,3 +199,23 @@ jobs:
           platform: ubuntu
           cache: enable
       - run: sui --version
+
+  wrpc: # Example of a project with artifacts not named the same as the main project
+    strategy:
+      matrix:
+        version: [ "latest" ]
+        runs-on: [ "ubuntu-latest" ]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v1
+      - run: npm ci
+      - run: npm run build
+      - uses: ./
+        with:
+          repo: bytecodealliance/wrpc
+          asset-name: wit-bindgen-wrpc
+          extension-matching: disable
+          rename-to: wit-bindgen-wrpc
+          chmod: 0755
+          cache: enable
+      - run: wit-bindgen-wrpc --version

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Caching helps avoid
 
 ### Changing Release File Extensions
 
-As described below this action defaults to assuming that a release is either a `.tar.gz` or a `.zip` archive but this 
+As described below this action defaults to assuming that a release is either a `.tar.gz` or a `.zip` archive but this
 may not always be true for all releases.  For example, a project might release a pure binary, a different archive format, a custom file extension etc.
 
-This action can change its extension-matching behavior via the `extension-matching` and `extension` parameters.  For 
+This action can change its extension-matching behavior via the `extension-matching` and `extension` parameters.  For
 example to match on a `.bz2` extension:
 
 ```yaml
@@ -97,8 +97,8 @@ jobs:
 
 Here the `extension` parameter is used to provide a regular expression for the file extension(s) you want to match.  If
 this is not specified then the action defaults to `\.(tag.gz|zip)`.  Since this is a regular expression being embedded into
-YAML be aware that you may need to provide an extra level of character escaping, in the above example we have a `\\` 
-used to escape the backslash and get an actual `\.` (literal match of the period character) in the regular 
+YAML be aware that you may need to provide an extra level of character escaping, in the above example we have a `\\`
+used to escape the backslash and get an actual `\.` (literal match of the period character) in the regular
 expression passed into the action.
 
 Alternatively, if a project produces pure binary releases with no file extension then you can install them as follows:
@@ -138,15 +138,37 @@ this case. The option `chmod` is applied to all binaries.
       chmod: 0755
 ```
 
-## Finding a release
+### Grab a single asset whose name differs from the repository
 
-By default, this action will look up the Platform and Architecture of the runner and use those values to interpolate and match a release package. **The release package name is first converted to lowercase**. The match pattern is:
+If the repository's release contains multiplie assets (e.g. for many projects),
+you can specify the name of the relevant asset with the `asset-name` parameter.
+Binary-related options (i.e. `rename-to`, `chmod`, and `extension-matching`)
+can be specified to control whether to treat the asset as binary and/or modify it.
 
-```js
-`(osPlatform|osArchs).*(osPlatform|osArchs).*\.(tar\.gz|zip)`;
+```yaml
+  - name: Install the latest wrpc version
+    uses: jaxxstorm/action-install-gh-release@v1.10.0
+    with:
+      repo: bytecodealliance/wrpc
+      asset-name: wit-bindgen-wrpc
+      rename-to: wit-bindgen-wrpc
+      chmod: 0755
+      extension-matching: disable
 ```
 
-Natively, the action will only match the following platforms: `linux`, `darwin`, `windows`.
+## Finding a release
+
+By default, this action will look up the Platform and Architecture of the runner and use those values to interpolate and match a release package. **The release package name is first converted to lowercase**.
+
+Multiple match patterns are used to find a viable asset:
+
+- Machine Architecture (e.g. `x86_64`, `arm64`, `amd64`)
+- (optional) Vendor (e.g. `musl`, `glibc`, `gnu`)
+- OS (e.g. `linux`, `darwin`)
+- Glibc implementation (e.g. `musl`, `glibc`, `gnu`)
+- (optional, via `extension-matching`) Extension (e.g. `tar.gz`, `zip`)
+
+Natively, the action will only match the following platforms (operating systems): `linux`, `darwin`, `windows`.
 
 Some examples of matches:
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,8 @@ const ThrottlingOctokit = GitHub.plugin(throttling);
 
 interface ToolInfo {
     owner: string;
-    project: string;
+    assetName: string;
+    repoName: string;
     tag: string;
     osPlatform: string;
     osArch: string;
@@ -57,7 +58,10 @@ async function run() {
             && tag !== "latest"
             && tag !== "";
 
-        const [owner, project] = repo.split("/")
+        const [owner, repoName] = repo.split("/")
+
+        // If a project name was manually configured, use it
+        const assetName = core.getInput("asset-name");
 
         let osMatch: string[] = []
 
@@ -83,23 +87,25 @@ async function run() {
         core.info(`==> System reported platform: ${os.platform()}`)
         core.info(`==> Using platform: ${osPlatform}`)
 
+        const osArchMatch: string[] = [];
+
         // Determine Architecture
         let osArch = core.getInput("arch");
         if (osArch === "") {
             osArch = os.arch()
             switch (os.arch()) {
                 case "x64":
-                    osMatch.push("x86_64", "x64", "amd64")
+                    osArchMatch.push("x86_64", "x64", "amd64")
                     break;
                 case "arm64":
-                    osMatch.push("aarch64", "arm64")
+                    osArchMatch.push("aarch64", "arm64")
                     break;
                 default:
-                    osMatch.push(os.arch())
+                    osArchMatch.push(os.arch())
                     break;
             }
         } else {
-            osMatch.push(osArch)
+            osArchMatch.push(osArch)
         }
         core.info(`==> System reported arch: ${os.arch()}`)
         core.info(`==> Using arch: ${osArch}`)
@@ -131,8 +137,9 @@ async function run() {
         }
 
         let toolInfo: ToolInfo = {
-            owner: owner,
-            project: project,
+            owner,
+            repoName,
+            assetName,
             tag: tag,
             osArch: osArch,
             osPlatform: osPlatform
@@ -154,7 +161,7 @@ async function run() {
         if (cacheEnabled && cacheKey !== undefined) {
             let ok = await cache.restoreCache([dest], cacheKey);
             if (ok !== undefined) {
-                core.info(`Found ${project} in the cache: ${dest}`)
+                core.info(`Found ${assetName} in the cache: ${dest}`)
                 core.info(`Adding ${finalBinLocation} to the path`);
                 core.addPath(finalBinLocation);
                 return;
@@ -165,22 +172,50 @@ async function run() {
         if (tag === "latest") {
             getReleaseUrl = await octokit.rest.repos.getLatestRelease({
                 owner: owner,
-                repo: project,
+                repo: repoName,
             })
         } else {
             getReleaseUrl = await octokit.rest.repos.getReleaseByTag({
                 owner: owner,
-                repo: project,
+                repo: repoName,
                 tag: tag,
             })
         }
 
+        // Build regular expressions for all the target triple components
+        //
+        // See: https://wiki.osdev.org/Target_Triplet
+        let osArchMatchRegexForm = `(${osArchMatch.join('|')})`
+        let osArchRegex = new RegExp(`${osArchMatchRegexForm}`);
+
+        let vendorRegex = new RegExp("(apple|linux|pc|unknown)?") // vendor may not be specified
+
         let osMatchRegexForm = `(${osMatch.join('|')})`
-        let re = new RegExp(`${osMatchRegexForm}.*${osMatchRegexForm}.*${extMatchRegexForm}`)
+        let osRegex = new RegExp(`${osMatchRegexForm}`);
+
+        let libcRegex = new RegExp("(gnu|glibc|musl)?"); // libc calling convention may not be specified
+
+        let extensionRegex = new RegExp(`${extMatchRegexForm}$`)
+
+        // Attempt to find the asset, with matches for arch, vendor, os, libc and extension as appropriate
         let asset = getReleaseUrl.data.assets.find(obj => {
-            core.info(`searching for ${obj.name} with ${re.source}`)
-            let normalized_obj_name = obj.name.toLowerCase()
-            return re.test(normalized_obj_name)
+            let normalized = obj.name.toLowerCase()
+            core.info(`checking for arch/vendor/os/glibc triple matches for (normalized) asset [${normalized}]`)
+
+            const nameIncluded = assetName ? normalized.includes(assetName) : true;
+            if (!nameIncluded) { core.debug(`name [${assetName}] wasn't included in [${normalized}]`); }
+            const osArchMatches = osArchRegex.test(normalized);
+            if (!osArchMatches) { core.debug("osArch didn't match"); }
+            const osMatches = osRegex.test(normalized);
+            if (!osMatches) { core.debug("os didn't match"); }
+            const vendorMatches = vendorRegex.test(normalized);
+            if (!vendorMatches) { core.debug("vendor didn't match"); }
+            const libcMatches = libcRegex.test(normalized);
+            if (!libcMatches) { core.debug("libc calling didn't match"); }
+            const extensionMatches = extensionRegex.test(normalized);
+            if (!extensionMatches) { core.debug("extenison didn't match"); }
+
+            return nameIncluded && osArchMatches && osMatches && vendorMatches && libcMatches && extensionMatches
         })
 
         if (!asset) {
@@ -192,7 +227,7 @@ async function run() {
 
         const url = asset.url
 
-        core.info(`Downloading ${project} from ${url}`)
+        core.info(`Downloading ${assetName} from ${url}`)
         const binPath = await tc.downloadTool(url,
             undefined,
             `token ${token}`,
@@ -302,7 +337,7 @@ async function run() {
 
         core.info(`Adding ${finalBinLocation} to the path`);
         core.addPath(finalBinLocation);
-        core.info(`Successfully installed ${project}`);
+        core.info(`Successfully installed ${assetName}`);
         core.info(`Binaries available at ${finalBinLocation}`);
     } catch (error) {
         if (error instanceof Error) {
@@ -319,12 +354,12 @@ function cachePrimaryKey(info: ToolInfo): string | undefined {
         return undefined;
     }
     return "action-install-gh-release/" +
-        `${info.owner}/${info.project}/${info.tag}/${info.osPlatform}-${info.osArch}`;
+        `${info.owner}/${info.assetName}/${info.tag}/${info.osPlatform}-${info.osArch}`;
 }
 
 function toolPath(info: ToolInfo): string {
     return path.join(getCacheDirectory(),
-        info.owner, info.project, info.tag,
+        info.owner, info.assetName, info.tag,
         `${info.osPlatform}-${info.osArch}`);
 }
 


### PR DESCRIPTION
This commit adds the ability to use configurable project names that are *separate* from the configured repo name (as in "<owner>/<repo>").

The main use case this feature enables is repositories that produce artifacts (possibly binary artifacts) which do not share the same name as the repository itself.

For example, project `some-owner/some-repo` may produce binary artifact `abc-amd64-linux` (<binary>-<arch>-<os>).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for configurable project names separate from repository names, with updates to `src/main.ts`, `.github/workflows/test.yml`, and `README.md`.
> 
>   - **Behavior**:
>     - Allow separate configuration of `project` name from `repo` name in `src/main.ts`.
>     - Update asset matching logic to include `project` name in `src/main.ts`.
>   - **GitHub Actions**:
>     - Add example job `wrpc` in `.github/workflows/test.yml` demonstrating separate `project` and `repo` names.
>   - **Documentation**:
>     - Update `README.md` to include usage of `project` parameter for different artifact names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Faction-install-gh-release&utm_source=github&utm_medium=referral)<sup> for 18451d2cb12c7a90c87c0e79aa5fc23dad70e72d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->