### PR TITLE
feat: support xz

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,3 +234,21 @@ jobs:
           repo: magnusopera/terrabuild
           prerelease: true
       - run: terrabuild version
+
+  weval: # Example of a project w/ .tar.xz artifact and extracted wrapping folder
+    strategy:
+      matrix:
+        version: [ "v0.3.2" ]
+        runs-on: [ "ubuntu-latest" ]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v1
+      - run: npm ci
+      - run: npm run build
+      - uses: ./
+        with:
+          repo: bytecodealliance/weval
+          tag: ${{ matrix.version }}
+          extension: "\\.xz"
+      - run:
+          weval --version

--- a/lib/main.js
+++ b/lib/main.js
@@ -41,6 +41,12 @@ const tc = __importStar(require("@actions/tool-cache"));
 const utils_1 = require("@actions/github/lib/utils");
 const plugin_throttling_1 = require("@octokit/plugin-throttling");
 const ThrottlingOctokit = utils_1.GitHub.plugin(plugin_throttling_1.throttling);
+const SUPPORTED_TAR_EXTENSIONS = [
+    '.tar.gz',
+    '.tar.xz',
+    '.tar.bz2',
+    '.tgz',
+];
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -69,8 +75,8 @@ function run() {
                 && tag !== "latest"
                 && tag !== "";
             const [owner, repoName] = repo.split("/");
-            // If a project name was manually configured, use it
-            const assetName = core.getInput("asset-name");
+            // Use configured project name if present
+            let assetName = core.getInput("asset-name");
             let osMatch = [];
             // Determine Platform
             let osPlatform = core.getInput("platform");
@@ -121,7 +127,7 @@ function run() {
             let extMatchRegexForm = "";
             if (extMatching) {
                 if (extension === "") {
-                    extMatchRegexForm = "\.(tar.gz|zip|tgz)";
+                    extMatchRegexForm = "\.(tar.gz|tar.xz|zip|tgz)";
                     core.info(`==> Using default file extension matching: ${extMatchRegexForm}`);
                 }
                 else {
@@ -250,16 +256,20 @@ function run() {
                 }
                 const extensionMatches = extensionRegex.test(normalized);
                 if (!extensionMatches) {
-                    core.debug("extenison didn't match");
+                    core.debug("extension didn't match");
                 }
-                return nameIncluded && osArchMatches && osMatches && vendorMatches && libcMatches && extensionMatches;
+                const matches = nameIncluded && osArchMatches && osMatches && vendorMatches && libcMatches && extensionMatches;
+                if (matches) {
+                    core.info(`artifact matched: ${normalized}`);
+                }
+                return matches;
             });
             if (!asset) {
                 const found = release.assets.map(f => f.name);
                 throw new Error(`Could not find asset for ${tag}. Found: ${found}`);
             }
             const url = asset.url;
-            core.info(`Downloading ${assetName} from ${url}`);
+            core.info(`Downloading ${asset.name} from ${url}`);
             const binPath = yield tc.downloadTool(url, undefined, `token ${token}`, {
                 accept: 'application/octet-stream'
             });
@@ -275,26 +285,41 @@ function run() {
                     yield extractFn(binPath, dest);
                 }
                 core.info(`Automatically extracted release asset ${asset.name} to ${dest}`);
-                const bins = fs.readdirSync(finalBinLocation, { withFileTypes: true })
-                    .filter(item => item.isFile())
-                    .map(bin => bin.name);
-                if (bins.length === 0)
+                // Attempt to find an extracted file that might be a binary matching the project
+                const binFiles = fs.readdirSync(finalBinLocation, { recursive: true, withFileTypes: true })
+                    .filter(item => item.name.includes(assetName) && item.isFile());
+                if (binFiles.length === 0)
                     throw new Error(`No files found in ${finalBinLocation}`);
-                else if (bins.length > 1 && renameTo !== "") {
+                else if (binFiles.length > 1 && renameTo !== "") {
                     core.warning("rename-to parameter ignored when installing \
                 a release from an archive that contains multiple files.");
                 }
-                if (chmodTo !== "") {
-                    bins.forEach(bin => {
-                        const binPath = path.join(finalBinLocation, bin);
+                // Ensure binaries that were found are in the dir that will be added to PATH
+                for (const { parentPath, name } of binFiles) {
+                    const currentBinPath = path.resolve(path.join(parentPath, name));
+                    const finalBinPath = path.resolve(path.join(finalBinLocation, name));
+                    // If the binary is in a path *other* than the one that will be added to PATH
+                    // copy it over
+                    if (currentBinPath != finalBinPath) {
                         try {
-                            fs.chmodSync(binPath, chmodTo);
-                            core.info(`chmod'd ${binPath} to ${chmodTo}`);
+                            core.debug(`detected binary not in folder on PATH, copying binary from [${currentBinPath}] to [${finalBinPath}]`);
+                            fs.copyFileSync(currentBinPath, finalBinPath);
+                        }
+                        catch (copyErr) {
+                            core.setFailed(`Failed to copy binary to folder in PATH: ${copyErr}`);
+                        }
+                    }
+                    // Apply chmod if configured
+                    if (chmodTo !== "") {
+                        try {
+                            fs.chmodSync(finalBinPath, chmodTo);
+                            core.info(`chmod'd ${finalBinPath} to ${chmodTo}`);
                         }
                         catch (chmodErr) {
-                            core.setFailed(`Failed to chmod ${binPath} to ${chmodTo}: ${chmodErr}`);
+                            core.setFailed(`Failed to chmod ${finalBinPath} to ${chmodTo}: ${chmodErr}`);
                         }
-                    });
+                    }
+                    core.info(`installed binary [${finalBinPath}] (present in PATH)`);
                 }
             }
             else {
@@ -387,7 +412,9 @@ function cachePrimaryKey(info) {
         `${info.owner}/${info.assetName}/${info.tag}/${info.osPlatform}-${info.osArch}`;
 }
 function toolPath(info) {
-    return path.join(getCacheDirectory(), info.owner, info.assetName, info.tag, `${info.osPlatform}-${info.osArch}`);
+    var _a;
+    let subDir = (_a = info.assetName) !== null && _a !== void 0 ? _a : info.repoName;
+    return path.join(getCacheDirectory(), info.owner, subDir, info.tag, `${info.osPlatform}-${info.osArch}`);
 }
 function getCacheDirectory() {
     const cacheDirectory = process.env['RUNNER_TOOL_CACHE'] || '';
@@ -397,7 +424,7 @@ function getCacheDirectory() {
     return cacheDirectory;
 }
 function getExtractFn(assetName) {
-    if (assetName.endsWith('.tar.gz') || assetName.endsWith('.tar.bz2') || assetName.endsWith('.tgz')) {
+    if (SUPPORTED_TAR_EXTENSIONS.some(ext => assetName.endsWith(ext))) {
         return tc.extractTar;
     }
     else if (assetName.endsWith('.zip')) {
@@ -408,7 +435,10 @@ function getExtractFn(assetName) {
     }
 }
 function getExtractFlags(assetName) {
-    if (assetName.endsWith('tar.bz2')) {
+    if (assetName.endsWith('tar.xz')) {
+        return "xJ";
+    }
+    else if (assetName.endsWith('tar.bz2')) {
         return "xj";
     }
     else {


### PR DESCRIPTION
This add support for `.tar.xz` files which are already supported by @actions/tool-cache upstream
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `.tar.xz` files in GitHub Actions workflow and main script, updating extension handling and extraction logic.
> 
>   - **Behavior**:
>     - Adds support for `.tar.xz` files in `src/main.ts` by updating `SUPPORTED_TAR_EXTENSIONS` and modifying regex in `run()`.
>     - Updates `getExtractFn()` to handle `.tar.xz` files.
>   - **Workflow**:
>     - Adds a new job `weval` in `.github/workflows/test.yml` to test `.tar.xz` file extraction.
>     - Uses `tar -xvf` to extract `.tar.xz` files in the `weval` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Faction-install-gh-release&utm_source=github&utm_medium=referral)<sup> for 0a1650b9246a587bdc63ceeaeee0d76b50fab169. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->