### PR TITLE
Fixes #110 - Add the asset-name input to the list of expected inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ inputs:
   binaries-location:
     description: "Specify this parameter if the binaries are not located in the root of the release archive. The parameter should be a relative path to the release archive. For example, if the binaries are located in the 'bin' directory of the release archive, the parameter should be 'bin'."
     required: false
+  asset-name:
+    description: "Use this parameter to specify the name of the asset to download if the repo has multiple assets."
+    required: false
 branding:
   icon: "archive"
   color: "green"


### PR DESCRIPTION
Fixes #110 by adding `asset-name` to the list of valid inputs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `asset-name` input to `action.yml` to specify asset name for download when multiple assets exist.
> 
>   - **Inputs**:
>     - Add `asset-name` input to `action.yml` to specify the asset name to download when multiple assets are present in a repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Faction-install-gh-release&utm_source=github&utm_medium=referral)<sup> for 232e6b779987c52a25e7b06bf65ee55ae48b8978. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->